### PR TITLE
adus.sh : symlink resloution for "CWD"

### DIFF
--- a/adus.sh
+++ b/adus.sh
@@ -41,7 +41,7 @@ function check_command {
 ## Configuration stuff
 
 # Dirctories
-CWD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+CWD=$( cd "$( dirname $( readlink "${BASH_SOURCE[0]}" ))" && pwd )
 DIR_TOOLS=$CWD/tools
 DIR_UNPACK=./unpacked
 DIR_SOURCE=./source


### PR DESCRIPTION
The program wasn't able to resole symlink; it can cause trouble if binary is symlinked to another directory.
I tested it on Fedora 21.
